### PR TITLE
Fix Testing Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,6 @@ end
 #spec/workers/bad_worker_spec.rb
 
 require "sidekiq_unique_jobs/testing"
-#OR
-require "sidekiq_unique_jobs/rspec/matchers"
 
 RSpec.describe BadWorker do
   specify { expect(described_class).to have_valid_sidekiq_options }


### PR DESCRIPTION
I ran into https://github.com/mhenrixon/sidekiq-unique-jobs/issues/741 pretty quickly when bringing this fantastic gem into a project.

It seems that the testing instructions are out of date. The "testing" lib does everything you need for RSpec, and includes necessary files.